### PR TITLE
Prevent go.sh from getting stuck on startup

### DIFF
--- a/go.sh
+++ b/go.sh
@@ -8,7 +8,7 @@ echo "Waiting up to ${WAIT}s for cassandra"
 int=5
 iter=$((WAIT / int))
 while [[ $iter -gt 0 ]]; do
-  if nc -w1 ${CASSANDRA} 9160; then
+  if nc -w1 -z ${CASSANDRA} 9160; then
     break
   fi
   sleep $((int - 1))


### PR DESCRIPTION
Under some circumstances, the `nc -w1 ${CASSANDRA} 9160` in go.sh seems to block forever if Cassandra is already up. Adding nc's `-z` flag fixed this for me. Maybe you'd want this, too.